### PR TITLE
Using slf4j-api instead of slf4j-simple

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ subprojects {
     // define some Bill of Materials (BOM) for all subprojects
     dependencies {
         // Logging API
-        api("org.slf4j", "slf4j-simple", libraryVersions["slf4j"])
+        api("org.slf4j", "slf4j-api", libraryVersions["slf4j"])
 
         // Needed for kotlin modules, provided at runtime via kotlin-osgi-bundle in karaf-features-ids
         api("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", libraryVersions["kotlin"])


### PR DESCRIPTION
`slf4j-simple` is an implementation. `slf4j-api` should be used instead, otherwise this will conflict, if you use this as a library in other projects, i.e. our OSGi-less trusted connector (which uses logback by default). We should not impose a choice of logging framework here.

Please re-publish the artefact after merging this.